### PR TITLE
Update kafka.init.conf

### DIFF
--- a/kafka/config/kafka.init.conf
+++ b/kafka/config/kafka.init.conf
@@ -22,6 +22,4 @@ pre-start script
 end script
 
 chdir {{ workdir }}
-script
- exec bin/kafka-server-start.sh config/server.properties
-end script
+exec bin/kafka-server-start.sh config/server.properties

--- a/kafka/config/kafka.init.conf
+++ b/kafka/config/kafka.init.conf
@@ -22,7 +22,6 @@ pre-start script
 end script
 
 chdir {{ workdir }}
-
 script
-    bin/kafka-server-start.sh config/server.properties
+ exec bin/kafka-server-start.sh config/server.properties
 end script


### PR DESCRIPTION
The Kafka start script exec's java, but when we wrap it in `script` and `end script` upstart is essentially supervising /bin/sh and not the JVM process. So it is parented under a process that looks like this:

```
 00:00:00 /bin/sh -e -c /usr/bin/kafka-server-start /etc/kafka/server.properties /bin/sh
```
There are a few issues. 
* Kafka registers a few signals handlers that with the exception of SIGTERM  and they will never run [Confluent source]( https://github.com/confluentinc/support-metrics-client/blob/master/support-metrics-client/src/main/java/io/confluent/support/metrics/SupportedKafka.java)
So, if we send a KILL -HUP to this process it won't be propagated to the JVM and the shutdown hook won't be run (more of a function of the shell being dash and not bash AFAICT). IF Dash is sent another signal then it sends a SIGHUP to everything in the process group, luckily Kafka has a handler for SIGHUP, but if it didn't it wouldn't exit and in the current configuration it may not exit at all still in some circumstances aside from kill -9 scenario.
** Kafka treats these signals the same anyway though that it registered by running the shutdown hook and in-fact there is no dynamic configuration functionality at the moment, yet, but this level of indirection I believe has some other problems too .
* The exit code won't be propagated to the supervising program correctly (the shell tends merge it with its exit code by adding 128+exit_code)
* Upstart will emit the started JOB=yourjob event as soon as it has executed dash, yet Kafka may not be actually ready yet.
* There's a small amount of system resources being used, and possibly issues with where stderr is redirected?
* Upstart tracks the wrong PID, so when we issue the stop if Kafka does not stop then another Kafka might start if we try to restart.

You can test that it's working incorrectly by sending a kill -HUP to the PID that is running /bin/sh and Kafka will not restart.

There are other precedents for exec'ing the kafka_start script this way and otherwise how to use script/exec/wrappers [1](https://github.com/dbtucker/cp-service/blob/master/cp-kafka-service#L74) [2](https://gerrit.wikimedia.org/r/#/c/284349/9/modules/confluent/templates/initscripts/kafka.systemd.erb)